### PR TITLE
Fix _assets/* dir cannot be load in publish github page due to all underscore dir will act like hidden file 

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Joplin Pages Publisher
 
-This plugin help you generate a static website from your picked Joplin notes, and publish it as [Github Pages](https://pages.github.com/) which are accessible on Web, **with a little mouse clicks, even if you know nothing about website building & publishing / Git / Github**.
+This plugin helps you generate a static website from your picked Joplin notes, and publish it as [Github Pages](https://pages.github.com/) which are accessible on Web, **with a few mouse clicks, even if you know nothing about website building & publishing / Git / Github**.
 
-Also, this plugin allow you to customize your website's theme, if you know something about HTML / CSS / JavaScript.
+Also, this plugin allows you to customize your website's theme, if you know something about HTML / CSS / JavaScript.
 
 Hope you enjoy it!
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "joplin-plugin-pages-publisher",
-  "version": "1.0.0",
+  "version": "1.0.2",
   "scripts": {
     "dist": "webpack --joplin-plugin-config buildMain && webpack --joplin-plugin-config buildExtraScripts && webpack --joplin-plugin-config createArchive",
     "dev": "cross-env NODE_ENV=development webpack --joplin-plugin-config buildMain && cross-env NODE_ENV=development webpack --joplin-plugin-config buildExtraScripts && cross-env NODE_ENV=development  webpack --joplin-plugin-config createArchive",

--- a/src/assets/default_theme/templates/_blocks/head.ejs
+++ b/src/assets/default_theme/templates/_blocks/head.ejs
@@ -1,4 +1,4 @@
 <meta charset="UTF-8" />
 <meta name="viewport" content="width=device-width, initial-scale=1.0" />
 <meta http-equiv="X-UA-Compatible" content="ie=edge" />
-<link rel="stylesheet" href="/_assets/main.css" />
+<link rel="stylesheet" href="/assets/main.css" />

--- a/src/driver/generator/joplinPlugin/PageRenderer.ts
+++ b/src/driver/generator/joplinPlugin/PageRenderer.ts
@@ -25,6 +25,7 @@ import {
   getThemeDir,
   getIcon,
   getOutputIcon,
+  getOutputNoJekyll,
 } from './pathHelper';
 
 ejs.fileLoader = fs.readFileSync;
@@ -322,6 +323,7 @@ export class PageRenderer {
     await this.copyAssets();
     await this.outputCname();
     await this.copyIcon();
+    await this.createNoJekyll();
     return await getAllFiles(this.outputDir);
   }
 
@@ -357,5 +359,14 @@ export class PageRenderer {
     } catch {
       return;
     }
+  }
+
+  // See https://stackoverflow.com/a/39691475/12420687
+  private async createNoJekyll() {
+    if (!this.outputDir) {
+      throw new Error('no output dir');
+    }
+
+    await fs.createFile(getOutputNoJekyll(this.outputDir));
   }
 }

--- a/src/driver/generator/joplinPlugin/pathHelper.ts
+++ b/src/driver/generator/joplinPlugin/pathHelper.ts
@@ -34,6 +34,10 @@ export function getOutputIcon(outputDir: string) {
   return `${outputDir}/favicon.ico`;
 }
 
+export function getOutputNoJekyll(outputDir: string) {
+  return `${outputDir}/.nojekyll`;
+}
+
 export async function getGitRepositoryDir() {
   return `${await joplin.plugins.dataDir()}/git_repository`;
 }

--- a/src/driver/generator/joplinPlugin/pathHelper.ts
+++ b/src/driver/generator/joplinPlugin/pathHelper.ts
@@ -23,7 +23,7 @@ export function getThemeAssetsDir(themeDir: string) {
 }
 
 export function getOutputThemeAssetsDir(outputDir: string) {
-  return `${outputDir}/_assets`;
+  return `${outputDir}/assets`;
 }
 
 export async function getIcon() {

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -2,11 +2,11 @@
   "manifest_version": 1,
   "id": "ylc395.pagesPublisher",
   "app_min_version": "2.0",
-  "version": "1.0.0",
+  "version": "1.0.2",
   "name": "Pages Publisher",
-  "description": "Generate static website from your Joplin notes, and publish to Github Pages, with a little mouse clicks",
+  "description": "Generate static blog website from your picked Joplin notes, and publish to Github Pages, with a few mouse clicks",
   "author": "ylc395",
-  "homepage_url": "https://github.com/ylc395/joplin-plugin-pages-publisher/wiki/User-Guide",
+  "homepage_url": "https://github.com/ylc395/joplin-plugin-pages-publisher",
   "repository_url": "https://github.com/ylc395/joplin-plugin-pages-publisher",
   "keywords": ["site generator", "github pages"]
 }


### PR DESCRIPTION
 Fix : `_assets` in src will transform to `assets` in outputDir. Fix the header in default theme too. 