### PR TITLE
Add configurable language code

### DIFF
--- a/src/assets/default_theme/config.json
+++ b/src/assets/default_theme/config.json
@@ -58,6 +58,12 @@
       "label": "Site Name",
       "rules": [{ "required": true }],
       "tip": "Site name displayed in left-top corner of every page"
+    },
+    {
+      "name": "lang",
+      "label": "Site Langage Code",
+      "rules": [{ "required": true }],
+      "tip": "The ISO 639-1 language code, used as the value of the `lang` attribute in the root HTML element"
     }
   ]
 }

--- a/src/assets/default_theme/templates/about.ejs
+++ b/src/assets/default_theme/templates/about.ejs
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="zh-cn">
+<html lang="<%= $site.lang %>">
   <head>
     <%- include('./_blocks/head') %>
     <title>About me - <%= $site.siteName %></title>

--- a/src/assets/default_theme/templates/archives.ejs
+++ b/src/assets/default_theme/templates/archives.ejs
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="zh-cn">
+<html lang="<%= $site.lang %>">
   <head>
     <%- include('./_blocks/head') %>
     <title>Archives - <%= $site.siteName %></title>

--- a/src/assets/default_theme/templates/article.ejs
+++ b/src/assets/default_theme/templates/article.ejs
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="zh-cn">
+<html lang="<%= $site.lang %>">
   <head>
     <%- include('./_blocks/head') %>
     <title><%= $article.title %> - <%= $site.siteName %></title>

--- a/src/assets/default_theme/templates/index.ejs
+++ b/src/assets/default_theme/templates/index.ejs
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="zh-cn" id="homepage">
+<html lang="<%= $site.lang %>" id="homepage">
   <head>
     <%- include('./_blocks/head') %>
     <title><%= $site.siteName %></title>


### PR DESCRIPTION
This pull request adds support for a configurable language code in the HTML root element (previously hard coded as zh-cn).

Note I'm not sure if this should be a required field. If it's not required, it should possibly default to `en` for English?

